### PR TITLE
Removed `str_replace` from the expression parsing.

### DIFF
--- a/src/LaravelTimezoneServiceProvider.php
+++ b/src/LaravelTimezoneServiceProvider.php
@@ -47,9 +47,7 @@ class LaravelTimezoneServiceProvider extends ServiceProvider
         Blade::directive(
             'displayDate',
             function ($expression) {
-
-                // list($date, $format, $format_timezone) = explode(',', str_replace(' ', '', $expression));
-                $options = explode(',', str_replace(' ', '', $expression));
+                $options = explode(',', $expression);
 
                 if (count($options) == 1) {
                     return "<?php echo e(Timezone::convertToLocal($options[0])); ?>";


### PR DESCRIPTION
Related to issue #10 

Just by removing that call, all spaces will be maintained.