### PR TITLE
Added ability to cast dates from the model using custom cast class

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,102 @@ And with custom formatting
 // 2018-07-04 3:32 New York, America
 ```
 
+### Using models casting class
+
+#### Basic usage
+
+```
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use JamesMills\LaravelTimezone\Casts\Timezone;
+
+class Foo extends Model
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => Timezone::class,
+    ];
+}
+```
+
+#### Advanced usage
+
+##### Custom format
+
+```
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use JamesMills\LaravelTimezone\Casts\Timezone;
+
+class Foo extends Model
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => Timezone::class.':Y-m-d H:i:s',
+    ];
+}
+```
+
+##### Return the timezone as a string passing along the format.
+
+```
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use JamesMills\LaravelTimezone\Casts\Timezone;
+
+class Foo extends Model
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => Timezone::class.':d/m/Y H:i:s,true',
+    ];
+}
+```
+
+##### Return the timezone as a string using the default format.
+
+```
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use JamesMills\LaravelTimezone\Casts\Timezone;
+
+class Foo extends Model
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => Timezone::class.':null,true',
+    ];
+}
+```
+
 ### Saving the users input to the database in UTC
 
 This will take a date/time, set it to the users timezone then return it as UTC in a Carbon instance.

--- a/src/Casts/Timezone.php
+++ b/src/Casts/Timezone.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace JamesMills\LaravelTimezone\Casts;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use \JamesMills\LaravelTimezone\Facades\Timezone as TimezoneFacade;
+
+class Timezone implements CastsAttributes
+{
+    /**
+     * @var null
+     */
+    private $format;
+
+    /**
+     * @var bool
+     */
+    private $showTimezone;
+
+    /**
+     * Timezone constructor.
+     * @param  null  $format
+     * @param  bool  $showTimezone
+     */
+    public function __construct($format = null, $showTimezone = false)
+    {
+        $this->format = $format === 'null' ? null : $format;
+        $this->showTimezone = filter_var($showTimezone, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return TimezoneFacade::convertToLocal(Carbon::parse($value), $this->format, $this->showTimezone);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  array  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return TimezoneFacade::convertFromLocal($value);
+    }
+}


### PR DESCRIPTION
Laravel gives us the ability to use custom classes when casting attributes directly from the model. 

Docs (https://laravel.com/docs/7.x/eloquent-mutators#custom-casts)

Basic usage

```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use JamesMills\LaravelTimezone\Casts\Timezone;

class Foo extends Model
{
    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [
        'created_at' => Timezone::class,
    ];
}
```

Advanced usage

Custom format

```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use JamesMills\LaravelTimezone\Casts\Timezone;

class Foo extends Model
{
    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [
        'created_at' => Timezone::class.':Y-m-d H:i:s',
    ];
}
```

Return the timezone as a string passing along the format.

```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use JamesMills\LaravelTimezone\Casts\Timezone;

class Foo extends Model
{
    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [
        'created_at' => Timezone::class.':d/m/Y H:i:s,true',
    ];
}
```

Return the timezone as a string using the default format.

```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use JamesMills\LaravelTimezone\Casts\Timezone;

class Foo extends Model
{
    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [
        'created_at' => Timezone::class.':null,true',
    ];
}
```