### PR TITLE
Clearing config before package installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12"
+    },
+    "scripts": {
+        "pre-package-install": [
+            "@php artisan config:clear"
+        ]
     }
 }


### PR DESCRIPTION
Added an event listener to clear config cache (#33).

The event used is `pre-package-install` [Composer Scripts - Package Events](https://getcomposer.org/doc/articles/scripts.md#package-events)

To read mode [Composer Scripts](https://getcomposer.org/doc/articles/scripts.md)
