### PR TITLE
Make the message shown to users when timezone is set configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ By default, the date format will be `jS F Y g:i:a`. To override this configurati
 
 This lookup array configuration makes it possible to find the remote address of the user in any attribute inside the Laravel `request` helper, by any key. Having in mind when the key is found inside the attribute, that key will be used. By default, we use the `server` attribute with the key `REMOTE_ADDR`. To override this configuration, you just need to change the `lookup` property inside the configuration file `config/timezone.php` for the desired lookup.
 
+### User Message
+
+You may configure the message shown to the user when the timezone is set by changing the `message` property inside the configuration file `config/timezone.php`
+
 ### Underlying GeoIp Package
 
 If you wish to customise the underlying `torann/geoip` package you can publish the config file by using the command below.

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -69,7 +69,7 @@ class UpdateUsersTimezone
             return;
         }
 
-        $message = sprintf(config('timezone.message', 'We have set your timezone to '), $geoip_info['timezone']);
+        $message = sprintf(config('timezone.message', 'We have set your timezone to %s'), $geoip_info['timezone']);
 
         if (config('timezone.flash') == 'laravel') {
             request()->session()->flash('success', $message);

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -69,7 +69,7 @@ class UpdateUsersTimezone
             return;
         }
 
-        $message = 'We have set your timezone to ' . $geoip_info['timezone'];
+        $message = sprintf(config('timezone.message', 'We have set your timezone to '), $geoip_info['timezone']);
 
         if (config('timezone.flash') == 'laravel') {
             request()->session()->flash('success', $message);

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -103,8 +103,8 @@ class UpdateUsersTimezone
     }
 
     /**
-    * @return mixed
-    */
+     * @return mixed
+     */
     private function getFromLookup()
     {
         $result = null;
@@ -134,7 +134,7 @@ class UpdateUsersTimezone
         $value = null;
 
         foreach ($keys as $key) {
-            if (!request()->$type->has($key)) {
+            if (! request()->$type->has($key)) {
                 continue;
             }
             $value = request()->$type->get($key);

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -12,7 +12,7 @@ class Timezone
      * @param  bool  $format_timezone
      * @return string
      */
-    public function convertToLocal(?Carbon $date, $format = null, $format_timezone = false) : string
+    public function convertToLocal(?Carbon $date, $format = null, $format_timezone = false): string
     {
         if (is_null($date)) {
             return 'Empty';
@@ -29,17 +29,36 @@ class Timezone
         $formatted_date_time = $date->format($format);
 
         if ($format_timezone) {
-            return $formatted_date_time . ' ' . $this->formatTimezone($date);
+            return $formatted_date_time.' '.$this->formatTimezone($date);
         }
 
         return $formatted_date_time;
     }
 
     /**
+     * @param  Carbon|null  $date
+     * @return string
+     */
+    public function convertToLocalDiffForHumans(?Carbon $date): string
+    {
+        if (is_null($date)) {
+            return 'Empty';
+        }
+
+        $timezone = (auth()->user()->timezone) ?? config('app.timezone');
+
+        $date->setTimezone($timezone);
+
+        $diffTime = Carbon::parse($date)->diffForHumans();
+
+        return $diffTime;
+    }
+
+    /**
      * @param $date
      * @return Carbon
      */
-    public function convertFromLocal($date) : Carbon
+    public function convertFromLocal($date): Carbon
     {
         return Carbon::parse($date, auth()->user()->timezone)->setTimezone('UTC');
     }
@@ -48,13 +67,13 @@ class Timezone
      * @param  Carbon  $date
      * @return string
      */
-    private function formatTimezone(Carbon $date) : string
+    private function formatTimezone(Carbon $date): string
     {
         $timezone = $date->format('e');
         $parts = explode('/', $timezone);
 
         if (count($parts) > 1) {
-            return str_replace('_', ' ', $parts[1]) . ', ' . $parts[0];
+            return str_replace('_', ' ', $parts[1]).', '.$parts[0];
         }
 
         return str_replace('_', ' ', $parts[0]);

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -58,5 +58,18 @@ return [
 
         ],
     ],
+    
+    
+    /*
+    |--------------------------------------------------------------------------
+    | User Message
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the message shown to the user when the timezone is set.
+    | Be sure to include the %s which will be replaced by the detected timezone.
+    | e.g. We have set your timezone to America/New_York
+    |
+    */
 
+	'message' => 'We have set your timezone to %s'
 ];


### PR DESCRIPTION
Added a `message` property to the config file to allow customization of the text. sprintf is used to include the identified timezone and the default message is utilized if the property is missing.