### PR TITLE
Multiple enhancements for new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 vendor
 composer.lock
+
+.history/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package listens for the `\Illuminate\Auth\Events\Login` event and will then
 
 This package uses the [torann/geoip](http://lyften.com/projects/laravel-geoip/doc/) package which looks up the users location based on their IP address. The package also returns information like the users currency and users timezone. [You can configure this package separately if you require](#custom-configuration).
 
- ## How to use
+## How to use
 
 You can show dates to your user in their timezone by using
 
@@ -36,23 +36,27 @@ Or use our nice blade directive
 
 ### Pull in the package using Composer
 
-```
+```bash
 composer require jamesmills/laravel-timezone
 ```
 
-### Publish database migrations
+### Default timezone attributes location
 
-```
+By default, timezone attributes placed into `users` table. If you wish to use package with this default, see instructions below.
+
+#### Publish database migrations
+
+```bash
 php artisan vendor:publish --provider="JamesMills\LaravelTimezone\LaravelTimezoneServiceProvider" --tag=migrations
 ```
 
 Run the database migrations. This will add `timezone` and `detect_timezone` columns to your `users` table. Note that migration will be placed to default Laravel migrations folder, so if you use custom folder, you should move migration file to appropriate location.
 
-```
+```bash
 php artisan migrate
 ```
 
-### Update User model
+#### Update User model
 
 Add `JamesMills\LaravelTimezone\Traits\HasTimezone` trait to your `user` model:
 
@@ -60,8 +64,7 @@ Add `JamesMills\LaravelTimezone\Traits\HasTimezone` trait to your `user` model:
 use HasTimezone;
 ```
 
-If you use package default attributes setup, `User` model has attribute `detect_timezone`.
-If you wish to work with it, you can add boolean cast for your `User` model:
+If you wish to work with `detect_timezone` attribute directly, you can add boolean cast for your `User` model:
 
 ```php
 protected $casts = [
@@ -69,11 +72,11 @@ protected $casts = [
 ];
 ```
 
-If you wish to use per-user timezone overwriting, you can add `detect_timezone` attribute to your `User` model fillable property:
+If you wish to set per-user timezone overwriting at user creation time, you can add `detect_timezone` attribute to your `User` model fillable property:
 
 ```php
 protected $fillable = [
-        'detect_timezone',
+    'detect_timezone',
     ];
 ```
 

--- a/src/LaravelTimezoneServiceProvider.php
+++ b/src/LaravelTimezoneServiceProvider.php
@@ -36,9 +36,9 @@ class LaravelTimezoneServiceProvider extends ServiceProvider
     public function boot()
     {
         // Allow migrations publish
-        if (! class_exists('AddTimezoneColumnToUsersTable')) {
+        if (!class_exists('AddTimezoneColumnsToUsersTable')) {
             $this->publishes([
-                __DIR__ . '/database/migrations/add_timezone_column_to_users_table.php.stub' => database_path('/migrations/' . date('Y_m_d_His') . '_add_timezone_column_to_users_table.php'),
+                __DIR__ . '/database/migrations/add_timezone_columns_to_users_table.php.stub' => database_path('/migrations/' . date('Y_m_d_His') . '_add_timezone_columns_to_users_table.php'),
             ], 'migrations');
         }
 

--- a/src/LaravelTimezoneServiceProvider.php
+++ b/src/LaravelTimezoneServiceProvider.php
@@ -17,6 +17,16 @@ class LaravelTimezoneServiceProvider extends ServiceProvider
      */
     protected $defer = false;
 
+    private function registerEventListener(): void
+    {
+        Event::listen(
+            config('timezone.timezone_check.events', null) ?? [
+                \Illuminate\Auth\Events\Login::class,
+                \Laravel\Passport\Events\AccessTokenCreated::class,
+            ],
+            config('timezone.timezone_check.listener', null) ?? UpdateUsersTimezone::class
+        );
+    }
 
     /**
      * Perform post-registration booting of services.
@@ -75,18 +85,5 @@ class LaravelTimezoneServiceProvider extends ServiceProvider
             __DIR__ . '/config/timezone.php',
             'timezone'
         );
-    }
-
-    /**
-     *
-     */
-    private function registerEventListener(): void
-    {
-        $events = [
-            \Illuminate\Auth\Events\Login::class,
-            \Laravel\Passport\Events\AccessTokenCreated::class,
-        ];
-
-        Event::listen($events, UpdateUsersTimezone::class);
     }
 }

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -126,9 +126,9 @@ class UpdateUsersTimezone
         }
 
         /**
-         * If no user is found, we just return. Nothing to do here.
+         * If no user is found or it has no timezone attribute, we just return.
          */
-        if ($user === null) {
+        if ($user === null || !property_exists($user, 'timezone')) {
             return;
         }
 

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -127,20 +127,27 @@ class UpdateUsersTimezone
         }
 
         /**
-         * If no user is found or it has no timezone attribute, we just return.
+         * If no user is found or it has no timezone-related methods, return.
          */
-        if ($user === null || !Schema::hasColumn($user->getTable(), 'timezone')) {
+        if (
+            $user === null ||
+            !method_exists($user, 'getTimezone') ||
+            !method_exists($user, 'getDetectTimezone') ||
+            !method_exists($user, 'setTimezone') ||
+            !method_exists($user, 'setDetectTimezone')
+        ) {
             return;
         }
 
-        $overwrite = $user->detect_timezone ?? config('timezone.overwrite', false);
+        $overwrite = $user->getDetectTimezone() ?? config('timezone.overwrite', true);
+        $timezone = $user->getTimezone();
 
-        if ($user->timezone === null || $overwrite === true) {
+        if ($timezone === null || $overwrite === true) {
             $info = $this->getGeoIpTimezone($this->getFromLookup());
 
-            if ($user->timezone === null || $user->timezone != $info['timezone']) {
+            if ($timezone === null || $timezone !== $info['timezone']) {
                 if ($info['timezone'] !== null) {
-                    $user->timezone = $info['timezone'];
+                    $user->setTimezone($info['timezone']);
                     $user->save();
                 }
 

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -25,7 +25,7 @@ class UpdateUsersTimezone
 
             $result = $this->lookup($type, $keys);
 
-            if (is_null($result)) {
+            if ($result === null) {
                 continue;
             }
         }
@@ -128,7 +128,7 @@ class UpdateUsersTimezone
         /**
          * If no user is found, we just return. Nothing to do here.
          */
-        if (is_null($user)) {
+        if ($user === null) {
             return;
         }
 

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -18,7 +18,7 @@ class UpdateUsersTimezone
     {
         $result = null;
 
-        foreach (config('timezone.lookup') as $type => $keys) {
+        foreach (config('timezone.lookup', []) as $type => $keys) {
             if (empty($keys)) {
                 continue;
             }
@@ -49,7 +49,7 @@ class UpdateUsersTimezone
 
     protected function notify(array $info): void
     {
-        if (config('timezone.flash') === 'off') {
+        if (config('timezone.flash', 'off') === 'off') {
             return;
         }
 

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -4,52 +4,15 @@ namespace JamesMills\LaravelTimezone\Listeners\Auth;
 
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Auth;
-use JamesMills\LaravelTimezone\Traits\RetrievesGeoIpTimezone;
+
 use Laravel\Passport\Events\AccessTokenCreated;
+use JamesMills\LaravelTimezone\Traits\FlashesMessage;
+use JamesMills\LaravelTimezone\Traits\RetrievesGeoIpTimezone;
 
 class UpdateUsersTimezone
 {
     use RetrievesGeoIpTimezone;
-
-    private function notify(array $info): void
-    {
-        if (config('timezone.flash') == 'off') {
-            return;
-        }
-
-        // TODO(sergotail): move to config, separate null and default timezone message case
-        $message = 'We have set your timezone to ' . $info['timezone'];
-
-        if (config('timezone.flash') == 'laravel') {
-            request()->session()->flash('success', $message);
-
-            return;
-        }
-
-        if (config('timezone.flash') == 'laracasts') {
-            flash()->success($message);
-
-            return;
-        }
-
-        if (config('timezone.flash') == 'mercuryseries') {
-            flashy()->success($message);
-
-            return;
-        }
-
-        if (config('timezone.flash') == 'spatie') {
-            flash()->success($message);
-
-            return;
-        }
-
-        if (config('timezone.flash') == 'mckenziearts') {
-            notify()->success($message);
-
-            return;
-        }
-    }
+    use FlashesMessage;
 
     private function getFromLookup(): ?string
     {
@@ -82,6 +45,59 @@ class UpdateUsersTimezone
         }
 
         return $value;
+    }
+
+    protected function notify(array $info): void
+    {
+        if (config('timezone.flash') === 'off') {
+            return;
+        }
+
+        if ($info['timezone'] === null) {
+            $key = config('timezone.messages.fail.key', 'error');
+            $message = config('timezone.messages.fail.message');
+        } else {
+            if ($info['default']) {
+                $key = config('timezone.messages.default.key', 'warning');
+                $message = config('timezone.messages.default.message');
+            } else {
+                $key = config('timezone.messages.success.key', 'info');
+                $message = config('timezone.messages.success.message');
+            }
+
+            if ($message !== null) {
+                $message = sprintf($message, $info['timezone']);
+            }
+        }
+
+        if ($message === null) {
+            return;
+        }
+
+        if (config('timezone.flash') === 'laravel') {
+            $this->flashLaravelMessage($key, $message);
+            return;
+        }
+
+        if (config('timezone.flash') === 'laracasts') {
+            $this->flashLaracastsMessage($key, $message);
+            return;
+        }
+
+        if (config('timezone.flash') === 'mercuryseries') {
+            $this->flashMercuryseriesMessage($key, $message);
+            return;
+        }
+
+        if (config('timezone.flash') === 'spatie') {
+            $this->flashSpatieMessage($key, $message);
+            return;
+        }
+
+        if (config('timezone.flash') === 'mckenziearts') {
+            $this->flashMckenzieartsMessage($key, $message);
+            return;
+        }
     }
 
     public function handle($event): void

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -4,7 +4,6 @@ namespace JamesMills\LaravelTimezone\Listeners\Auth;
 
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Schema;
 
 use Laravel\Passport\Events\AccessTokenCreated;
 use JamesMills\LaravelTimezone\Traits\FlashesMessage;

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -4,6 +4,7 @@ namespace JamesMills\LaravelTimezone\Listeners\Auth;
 
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
 
 use Laravel\Passport\Events\AccessTokenCreated;
 use JamesMills\LaravelTimezone\Traits\FlashesMessage;
@@ -128,11 +129,13 @@ class UpdateUsersTimezone
         /**
          * If no user is found or it has no timezone attribute, we just return.
          */
-        if ($user === null || !property_exists($user, 'timezone')) {
+        if ($user === null || !Schema::hasColumn($user->getTable(), 'timezone')) {
             return;
         }
 
-        if ($user->timezone === null || config('timezone.overwrite', false) === true) {
+        $overwrite = $user->detect_timezone ?? config('timezone.overwrite', false);
+
+        if ($user->timezone === null || $overwrite === true) {
             $info = $this->getGeoIpTimezone($this->getFromLookup());
 
             if ($user->timezone === null || $user->timezone != $info['timezone']) {

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -44,7 +44,7 @@ class Timezone
             return config('timezone.empty_date', 'Empty');
         }
 
-        $formatted = $date->format($format ?? config('timezone.format'));
+        $formatted = $date->format($format ?? config('timezone.format', 'jS F Y g:i:a'));
 
         if ($displayTimezone) {
             return $formatted . ' ' . $this->formatTimezone($date);

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -26,7 +26,7 @@ class Timezone
 
         // TODO(sergotail): use geoip timezone suggestion for non-authorized users too
         // (make it configurable)
-        $timezone = auth()->user()->timezone ??
+        $timezone = auth()->user()->getTimezone() ??
             config('timezone.default', null) ??
             config('app.timezone');
 
@@ -55,6 +55,6 @@ class Timezone
 
     public function convertFromLocal($date): Carbon
     {
-        return Carbon::parse($date, auth()->user()->timezone)->setTimezone('UTC');
+        return Carbon::parse($date, auth()->user()->getTimezone())->setTimezone('UTC');
     }
 }

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -6,11 +6,7 @@ use Carbon\Carbon;
 
 class Timezone
 {
-    /**
-     * @param  Carbon\Carbon  $date
-     * @return string
-     */
-    private function formatTimezone(Carbon $date): string
+    protected function formatTimezone(Carbon $date): string
     {
         $timezone = $date->format('e');
         $parts = explode('/', $timezone);
@@ -22,43 +18,42 @@ class Timezone
         return str_replace('_', ' ', $parts[0]);
     }
 
-    /**
-     * @param  Carbon\Carbon|null  $date
-     * @param  null  $format
-     * @param  bool  $format_timezone
-     * @return string
-     */
+    public function toLocal(?Carbon $date): ?Carbon
+    {
+        if ($date === null) {
+            return null;
+        }
+
+        // TODO(sergotail): use geoip timezone suggestion for non-authorized users too
+        // (make it configurable)
+        $timezone = auth()->user()->timezone ??
+            config('timezone.default', null) ??
+            config('app.timezone');
+
+        return $date->copy()->setTimezone($timezone);
+    }
+
     public function convertToLocal(
         ?Carbon $date,
-        $format = null,
-        $format_timezone = false
+        ?string $format = null,
+        bool $displayTimezone = false
     ): string {
-        if (is_null($date)) {
+        $date = $this->toLocal($date);
+
+        if ($date === null) {
             return config('timezone.empty_date', 'Empty');
         }
 
-        $timezone = (auth()->user()->timezone) ?? config('app.timezone');
+        $formatted = $date->format($format ?? config('timezone.format'));
 
-        $date->setTimezone($timezone);
-
-        if (is_null($format)) {
-            return $date->format(config('timezone.format'));
+        if ($displayTimezone) {
+            return $formatted . ' ' . $this->formatTimezone($date);
         }
 
-        $formatted_date_time = $date->format($format);
-
-        if ($format_timezone) {
-            return $formatted_date_time . ' ' . $this->formatTimezone($date);
-        }
-
-        return $formatted_date_time;
+        return $formatted;
     }
 
-    /**
-     * @param $date
-     * @return Carbon\Carbon
-     */
-    public function convertFromLocal($date) : Carbon
+    public function convertFromLocal($date): Carbon
     {
         return Carbon::parse($date, auth()->user()->timezone)->setTimezone('UTC');
     }

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -7,15 +7,34 @@ use Carbon\Carbon;
 class Timezone
 {
     /**
+     * @param  Carbon\Carbon  $date
+     * @return string
+     */
+    private function formatTimezone(Carbon $date): string
+    {
+        $timezone = $date->format('e');
+        $parts = explode('/', $timezone);
+
+        if (count($parts) > 1) {
+            return str_replace('_', ' ', $parts[1]) . ', ' . $parts[0];
+        }
+
+        return str_replace('_', ' ', $parts[0]);
+    }
+
+    /**
      * @param  Carbon\Carbon|null  $date
      * @param  null  $format
      * @param  bool  $format_timezone
      * @return string
      */
-    public function convertToLocal(?Carbon $date, $format = null, $format_timezone = false) : string
-    {
+    public function convertToLocal(
+        ?Carbon $date,
+        $format = null,
+        $format_timezone = false
+    ): string {
         if (is_null($date)) {
-            return 'Empty';
+            return config('timezone.empty_date', 'Empty');
         }
 
         $timezone = (auth()->user()->timezone) ?? config('app.timezone');
@@ -42,21 +61,5 @@ class Timezone
     public function convertFromLocal($date) : Carbon
     {
         return Carbon::parse($date, auth()->user()->timezone)->setTimezone('UTC');
-    }
-
-    /**
-     * @param  Carbon\Carbon  $date
-     * @return string
-     */
-    private function formatTimezone(Carbon $date) : string
-    {
-        $timezone = $date->format('e');
-        $parts = explode('/', $timezone);
-
-        if (count($parts) > 1) {
-            return str_replace('_', ' ', $parts[1]) . ', ' . $parts[0];
-        }
-
-        return str_replace('_', ' ', $parts[0]);
     }
 }

--- a/src/Traits/FlashesMessage.php
+++ b/src/Traits/FlashesMessage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace JamesMills\LaravelTimezone\Traits;
+
+trait FlashesMessage
+{
+    protected function flashLaravelMessage(string $key, string $message): void
+    {
+        request()->session()->flash($key, $message);
+    }
+
+    protected function flashLaracastsMessage(string $key, string $message): void
+    {
+        flash()->success($message);
+    }
+
+    protected function flashMercuryseriesMessage(string $key, string $message): void
+    {
+        flashy()->success($message);
+    }
+
+    protected function flashSpatieMessage(string $key, string $message): void
+    {
+        flash()->success($message);
+    }
+
+    protected function flashMckenzieartsMessage(string $key, string $message): void
+    {
+        notify()->success($message);
+    }
+}

--- a/src/Traits/HasTimezone.php
+++ b/src/Traits/HasTimezone.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace JamesMills\LaravelTimezone\Traits;
+
+trait HasTimezone
+{
+    public function getTimezone(): ?string
+    {
+        $timezone = $this->timezone;
+        if ($timezone === null) {
+            return null;
+        }
+
+        return (string) $timezone;
+    }
+
+    public function getDetectTimezone(): ?bool
+    {
+        $detectTimezone = $this->detect_timezone;
+        if ($detectTimezone === null) {
+            return null;
+        }
+
+        return (bool) $detectTimezone;
+    }
+
+    public function setTimezone(?string $timezone)
+    {
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    public function setDetectTimezone(?bool $detectTimezone)
+    {
+        $this->detect_timezone = $detectTimezone;
+
+        return $this;
+    }
+}

--- a/src/Traits/RetrievesGeoIpTimezone.php
+++ b/src/Traits/RetrievesGeoIpTimezone.php
@@ -9,7 +9,7 @@ trait RetrievesGeoIpTimezone
         $info = geoip()->getLocation($ip);
 
         return [
-            'timezone' => $info['timezone'] ?? ($info['time_zone'] ?? [])['name'] ?? null,
+            'timezone' => ($info['time_zone'] ?? [])['name'] ?? ($info['timezone'] ?? null),
             'default' => $info['default'] ?? false,
         ];
     }

--- a/src/Traits/RetrievesGeoIpTimezone.php
+++ b/src/Traits/RetrievesGeoIpTimezone.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JamesMills\LaravelTimezone\Traits;
+
+trait RetrievesGeoIpTimezone
+{
+    protected function getGeoIpTimezone(?string $ip): array
+    {
+        $info = geoip()->getLocation($ip);
+
+        return [
+            'timezone' => $info['timezone'] ?? ($info['time_zone'] ?? [])['name'] ?? null,
+            'default' => $info['default'] ?? false,
+        ];
+    }
+}

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -33,7 +33,7 @@ return [
     | Lookup Array
     |--------------------------------------------------------------------------
     |
-    | Here you may configure the lookup array whom it will be used to fetch 
+    | Here you may configure the lookup array whom it will be used to fetch
     | the user remote address.
     | When a key is found inside the lookup array that key it will be used.
     |

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -61,6 +61,7 @@ return [
     |
     | Here you may configure if you would like to overwrite existing
     | timezones if they have been already set in the database.
+    | Note that this is default value, per-user value checked for existence first.
     | options [true, false]
     |
     */

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -18,7 +18,7 @@ return [
     'timezone_check' => [
         /*
         |--------------------------------------------------------------------------
-        | Timezone check events
+        | Timezone Check Events
         |--------------------------------------------------------------------------
         |
         | Here you may configure which events will be listen for user timezone check.
@@ -38,7 +38,7 @@ return [
 
         /*
         |--------------------------------------------------------------------------
-        | Timezone check event listener
+        | Timezone Check Event Listener
         |--------------------------------------------------------------------------
         |
         | Here you may configure which event handler will be used for user timezone check.
@@ -81,10 +81,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Empty Date 
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure string to show when date is null.
+    | If null specified, string 'Empty' will be used.
+    |
+    */
+
+    'empty_date' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Lookup Array
     |--------------------------------------------------------------------------
     |
-    | Here you may configure the lookup array whom it will be used to fetch the user remote address.
+    | Here you may configure the lookup array whom it will be used to fetch 
+    | the user remote address.
     | When a key is found inside the lookup array that key it will be used.
     |
     */

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -15,6 +15,45 @@ return [
 
     'flash' => 'laravel',
 
+    'timezone_check' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Timezone check events
+        |--------------------------------------------------------------------------
+        |
+        | Here you may configure which events will be listen for user timezone check.
+        | If null specified, default Laravel Login and AccessTokenCreated events will be listen.
+        | This option is useful only if custom event handler for custom events specified.
+        | Examples:
+        | 1) null
+        | 2) \App\Events\MyLoginEvent::class
+        | 3) [
+        |         \App\Events\MyLoginEvent1::class,
+        |         \App\Events\MyLoginEvent2::class,
+        |    ]
+        |
+        */
+
+        'events' => null,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Timezone check event listener
+        |--------------------------------------------------------------------------
+        |
+        | Here you may configure which event handler will be used for user timezone check.
+        | If null specified, package default event listener will be used.
+        | This option is useful only if you are using custom login events or want to
+        | override default event listener, e.g. RetrievesGeoIpTimezone trait.
+        | Examples:
+        | null
+        | \App\EventListeners\MyTimezoneCheckEventListener::class
+        |
+        */
+
+        'listener' => null,
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Overwrite Existing Timezone
@@ -54,9 +93,7 @@ return [
         'server' => [
             'REMOTE_ADDR',
         ],
-        'headers' => [
-
-        ],
+        'headers' => [],
     ],
 
 ];

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -93,6 +93,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure default timezone for requests with no auth user info.
+    | If null specified, app.timezone config value will be used.
+    |
+    */
+
+    'default' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Lookup Array
     |--------------------------------------------------------------------------
     |

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -96,4 +96,30 @@ return [
         'headers' => [],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Lookup Array
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure flash messages for timezone setup results.
+    | If null specified, no message will be flashed for current case.
+    |
+    */
+
+    'messages' => [
+        'fail' => [
+            'key' => 'error',
+            'message' => 'We cannot determine your timezone',
+        ],
+
+        'default' => [
+            'key' => 'warning',
+            'message' => 'We cannot determine your timezone and have set it to default: %s',
+        ],
+
+        'success' => [
+            'key' => 'info',
+            'message' => 'We have set your timezone to %s',
+        ],
+    ],
 ];

--- a/src/config/timezone.php
+++ b/src/config/timezone.php
@@ -4,6 +4,74 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure default timezone for requests with no auth user info.
+    | If null specified, app.timezone config value will be used.
+    |
+    */
+
+    'default' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Overwrite Existing Timezone Default Value
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure if you would like to overwrite existing
+    | timezones if they have been already set in the database.
+    | Note that this is default value, per-user value checked for existence first.
+    | options [true, false]
+    |
+    */
+
+    'overwrite' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lookup Array
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the lookup array whom it will be used to fetch 
+    | the user remote address.
+    | When a key is found inside the lookup array that key it will be used.
+    |
+    */
+
+    'lookup' => [
+        'server' => [
+            'REMOTE_ADDR',
+        ],
+        'headers' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | DateTime Default Format
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure if you would like to overwrite the
+    | default format.
+    |
+    */
+
+    'format' => 'jS F Y g:i:a',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Empty DateTime String
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure string to show when date is null.
+    | If null specified, string 'Empty' will be used.
+    |
+    */
+
+    'empty_date' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Flash messages
     |--------------------------------------------------------------------------
     |
@@ -14,6 +82,33 @@ return [
     */
 
     'flash' => 'laravel',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lookup Array
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure flash messages for timezone setup results.
+    | If null specified, no message will be flashed for current case.
+    |
+    */
+
+    'messages' => [
+        'fail' => [
+            'key' => 'error',
+            'message' => 'We cannot determine your timezone',
+        ],
+
+        'default' => [
+            'key' => 'warning',
+            'message' => 'We cannot determine your timezone and have set it to default: %s',
+        ],
+
+        'success' => [
+            'key' => 'info',
+            'message' => 'We have set your timezone to %s',
+        ],
+    ],
 
     'timezone_check' => [
         /*
@@ -52,100 +147,5 @@ return [
         */
 
         'listener' => null,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Overwrite Existing Timezone
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure if you would like to overwrite existing
-    | timezones if they have been already set in the database.
-    | Note that this is default value, per-user value checked for existence first.
-    | options [true, false]
-    |
-    */
-
-    'overwrite' => true,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Overwrite Default Format
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure if you would like to overwrite the
-    | default format.
-    |
-    */
-
-    'format' => 'jS F Y g:i:a',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Empty Date 
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure string to show when date is null.
-    | If null specified, string 'Empty' will be used.
-    |
-    */
-
-    'empty_date' => null,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Default Timezone
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure default timezone for requests with no auth user info.
-    | If null specified, app.timezone config value will be used.
-    |
-    */
-
-    'default' => null,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Lookup Array
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure the lookup array whom it will be used to fetch 
-    | the user remote address.
-    | When a key is found inside the lookup array that key it will be used.
-    |
-    */
-
-    'lookup' => [
-        'server' => [
-            'REMOTE_ADDR',
-        ],
-        'headers' => [],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Lookup Array
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure flash messages for timezone setup results.
-    | If null specified, no message will be flashed for current case.
-    |
-    */
-
-    'messages' => [
-        'fail' => [
-            'key' => 'error',
-            'message' => 'We cannot determine your timezone',
-        ],
-
-        'default' => [
-            'key' => 'warning',
-            'message' => 'We cannot determine your timezone and have set it to default: %s',
-        ],
-
-        'success' => [
-            'key' => 'info',
-            'message' => 'We have set your timezone to %s',
-        ],
     ],
 ];

--- a/src/database/migrations/add_timezone_columns_to_users_table.php.stub
+++ b/src/database/migrations/add_timezone_columns_to_users_table.php.stub
@@ -2,8 +2,9 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-class AddTimezoneColumnToUsersTable extends Migration
+class AddTimezoneColumnsToUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -17,6 +18,12 @@ class AddTimezoneColumnToUsersTable extends Migration
                 $table->string('timezone')->after('remember_token')->nullable();
             });
         }
+
+        if (!Schema::hasColumn('users', 'detect_timezone')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('detect_timezone')->after('timezone')->default(false);
+            });
+        }
     }
 
     /**
@@ -28,6 +35,7 @@ class AddTimezoneColumnToUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('timezone');
+            $table->dropColumn('detect_timezone');
         });
     }
 }

--- a/src/database/migrations/add_timezone_columns_to_users_table.php.stub
+++ b/src/database/migrations/add_timezone_columns_to_users_table.php.stub
@@ -21,7 +21,7 @@ class AddTimezoneColumnsToUsersTable extends Migration
 
         if (!Schema::hasColumn('users', 'detect_timezone')) {
             Schema::table('users', function (Blueprint $table) {
-                $table->boolean('detect_timezone')->after('timezone')->default(false);
+                $table->boolean('detect_timezone')->after('timezone')->nullable();
             });
         }
     }


### PR DESCRIPTION
- Added customization for events and event listener to its overrideing and usage of custom events
- Added customization for flash messages, added separate trait for it to allow event listener overriding
- GeoIP timezone info retrieval now is in separate trait for customization, also fixed its logic to work with different geoip info formats
- Added empty date/datetime string customization
- Added `Timezone::toLocal` method to use `Carbon` instance with set user-side timezone, e.g. for `diffForHumans` usage
- Added per-user timezone overwrite flag
- Added HasTimezone trait to support different package timezone attributes data sources, not only `users` table
- Minor codestyle fixes done