### PR TITLE
Take the first found IP from 'lookup' config key

### DIFF
--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -46,6 +46,13 @@ class UpdateUsersTimezone
             return;
         }
 
+        /**
+         * Overwrite mode is not active and user timezone is already set. Nothing to do here.
+         */
+        if (config('timezone.overwrite') == false && $user->timezone != null) {
+            return;
+        }
+        
         $ip = $this->getFromLookup();
         $geoip_info = geoip()->getLocation($ip);
 

--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -140,10 +140,9 @@ class UpdateUsersTimezone
         $value = null;
 
         foreach ($keys as $key) {
-            if (!request()->$type->has($key)) {
-                continue;
+            if (request()->$type->has($key)) {
+                return request()->$type->get($key);
             }
-            $value = request()->$type->get($key);
         }
 
         return $value;


### PR DESCRIPTION
At this moment, if IP is not found, the loop skips but eventually the last resolved IP is taken.

IMHO it should be the first IP grabbed, for example I'd like to get real user IP from cloudflare using this code:
```php
'lookup' => [
        'server' => [
            'HTTP_CF_CONNECTING_IP',
            'REMOTE_ADDR',
        ],
        'headers' => [

        ],
    ],
```

Now, I need to use `'HTTP_CF_CONNECTING_IP'` as the last option which is not intuitive, and we unnecessarily loop through all the items.

Solves: https://github.com/jamesmills/laravel-timezone/issues/78