### PR TITLE
Add laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "laravel/framework": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
+        "laravel/framework": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8 || ^9",
         "torann/geoip": "^3.0",
         "nesbot/carbon": "^1.0 || ^2.0",
         "treeware/plant": "dev-main"


### PR DESCRIPTION
I don't think there needs to be anything else, since the php requirement is >= 7.4, which includes Laravel 9's minimum requirement of 8