### PR TITLE
Disable geo lookup if not necessary

### DIFF
--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -46,6 +46,13 @@ class UpdateUsersTimezone
             return;
         }
 
+        /**
+         * Overwrite mode is not active and user timezone is already set. Nothing to do here.
+         */
+        if (config('timezone.overwrite') == false && $user->timezone != null) {
+            return;
+        }
+        
         $ip = $this->getFromLookup();
         $geoip_info = geoip()->getLocation($ip);
 


### PR DESCRIPTION
Let's save the world and don't do geo lookup when overwrite mode is not active and user timezone is already set