### PR TITLE
Fix Session store not set on request

### DIFF
--- a/src/Listeners/Auth/UpdateUsersTimezone.php
+++ b/src/Listeners/Auth/UpdateUsersTimezone.php
@@ -64,7 +64,7 @@ class UpdateUsersTimezone
      */
     private function notify(Location $geoip_info)
     {
-        if (request()->hasSession() && config('timezone.flash') == 'off') {
+        if (!request()->hasSession() || config('timezone.flash') == 'off') {
             return;
         }
 


### PR DESCRIPTION
This change fixes the error in `vendor/laravel/framework/src/Illuminate/Http/Request.php:560` when the request does not have a session. This happens to me when I use the package with Laravel Passport. 

The previous evaluation was incorrect since if the request does not have a session but the configuration variable is not "off" it still evaluates to false and the execution of the code continues.

With the change I made in this PR the execution of the code will continue only when the request has a session and config('timezone.flash') is not  "off".

Setting the config('timezone.flash') to "off" also fixes the problem as mentioned here but i think is not the right solution for the problem: https://github.com/jamesmills/laravel-timezone/issues/59#issuecomment-914325684